### PR TITLE
returning_to_only_start_date

### DIFF
--- a/models/staging/base/base_ga4__events.sql
+++ b/models/staging/base/base_ga4__events.sql
@@ -12,6 +12,7 @@
             "field": "event_date_dt",
             "data_type": "date",
         },
+        partitions = partitions_to_replace,
         cluster_by=['event_name']
     )
 }}
@@ -21,8 +22,9 @@ with source as (
         {{ ga4.base_select_source() }}
     from {{ source('ga4', 'events') }}
     where dt >= parse_date('%Y%m%d', {{var('start_date')}})
-    and dt < parse_date('%Y%m%d', {{var('end_date')}})
- 
+    {% if is_incremental() %}
+        and dt in ({{ partitions_to_replace | join(',') }})
+    {% endif %}
 ),
 renamed as (
     select


### PR DESCRIPTION
## Description & motivation
After filling in all the data for the year 2024, the original state of only using `start_date` >= xxxxxx in `dbt_project.yml` is returned.

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have run `dbt test` and `python -m pytest .` to validate existing tests
